### PR TITLE
rename `children` to `configurables`

### DIFF
--- a/lib/src/scopes/configurables/configurable.dart
+++ b/lib/src/scopes/configurables/configurable.dart
@@ -11,7 +11,7 @@ abstract class Configurable {
 
   const factory Configurable(ScopeConfigure configure) = ConfigurableFunction;
   const factory Configurable.combine({
-    required List<Configurable> children,
+    required List<Configurable> configurables,
   }) = ConfigurableCombine.impl;
 }
 

--- a/lib/src/scopes/configurables/configurable_combine.dart
+++ b/lib/src/scopes/configurables/configurable_combine.dart
@@ -11,7 +11,7 @@ abstract class ConfigurableCombine extends ConfigurableCompose {
 
   @internal
   const factory ConfigurableCombine.impl({
-    required List<Configurable> children,
+    required List<Configurable> configurables,
   }) = _ConfigurableCombineImpl;
 
   List<Configurable> combine();
@@ -30,13 +30,13 @@ Configurable _combineConfigure(List<Configurable> configure) {
 class _ConfigurableCombineImpl extends ConfigurableCombine {
 
   const _ConfigurableCombineImpl ({
-    required List<Configurable> children,
-  }): _children = children;
+    required List<Configurable> configurables,
+  }): _configurables = configurables;
 
-  final List<Configurable> _children;
+  final List<Configurable> _configurables;
 
   @override
   List<Configurable> combine() {
-    return _children;
+    return _configurables;
   }
 }

--- a/test/scopes/configurables/configurable_combine_test.dart
+++ b/test/scopes/configurables/configurable_combine_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     final combine = Configurable.combine(
-      children: [
+      configurables: [
         configurable1,
         configurable2,
       ],
@@ -52,7 +52,7 @@ void main() {
     });
 
     final combine = Configurable.combine(
-      children: [
+      configurables: [
         configurable1,
         configurable2,
       ],
@@ -70,10 +70,10 @@ void main() {
 
   });
 
-  test('`Configurable.combine` make sync scope if children only has sync configuration', () {
+  test('`Configurable.combine` make sync scope if configurables only has sync configuration', () {
 
     final combine = Configurable.combine(
-      children: [
+      configurables: [
         MockConfigurable((scope) {}),
       ],
     );
@@ -86,10 +86,10 @@ void main() {
 
   });
 
-  test('`Configurable.combine` make async scope if children has async configuration', () {
+  test('`Configurable.combine` make async scope if configurables has async configuration', () {
 
     final combine = Configurable.combine(
-      children: [
+      configurables: [
         MockConfigurable((scope) async {}),
       ],
     );


### PR DESCRIPTION
rename `children` to `configurables`